### PR TITLE
resize the bbox with true size

### DIFF
--- a/script/extract_features_from_gt.py
+++ b/script/extract_features_from_gt.py
@@ -98,7 +98,7 @@ class FeatureExtractor:
             ).to("cuda")
             orig_image_size = (img_info["width"], img_info["height"])
             boxes = BoxList(boxes_tensor, orig_image_size)
-            image_size = (images.image_sizes[idx][1], images.image_sizes[idx][0])
+            image_size = (img_info["scale_width"], img_info["scale_height"])
             boxes = boxes.resize(image_size)
             proposals_batch.append(boxes)
         return proposals_batch
@@ -130,7 +130,12 @@ class FeatureExtractor:
         )
         img = torch.from_numpy(im).permute(2, 0, 1)
 
-        im_info = {"width": im_width, "height": im_height}
+        im_info = {
+            "width": im_width, 
+            "height": im_height,
+            "scale_width": img.shape[2],
+            "scale_height": img.shape[1],
+            }
 
         return img, im_scale, im_info
 


### PR DESCRIPTION
Great work!

Here is why I create this PR:
1. 
Original script use
`image_size = (images.image_sizes[idx][1], images.image_sizes[idx][0])`
to resize bbox, which is incorrect because this size is padded with zeros.
We should use original scaled size to resize the bbox.

2. 
Also, in the data/README, you say that the format is "x, y, w, h".
However, you use `mode=xyxy` in your implementation.
So, I think you should slightly modify your README.

Thank you.